### PR TITLE
Create InvokedFunctionArn if it doesn't exist

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -1,8 +1,6 @@
 package iopipe
 
 import (
-	"crypto/rand"
-	"io"
 	"runtime"
 	"time"
 )
@@ -21,7 +19,7 @@ var (
 	loadTime = int(time.Now().UnixNano() / 1e6)
 
 	// processID is the ID for this process
-	processID = getProcessID()
+	processID = generateUUID()
 
 	// RuntimeVersion is the golang runtime version (minus "go" prefix)
 	runtimeVersion = runtime.Version()[2:]
@@ -34,14 +32,3 @@ const (
 	// RUNTIME is the runtime of the IOpipe agent
 	RUNTIME = "go"
 )
-
-// getProcessID returns a unique identifier for this process
-func getProcessID() string {
-	var uuid UUID
-	io.ReadFull(rand.Reader, uuid[:])
-
-	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
-	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
-
-	return uuid.String()
-}

--- a/handler_wrapper.go
+++ b/handler_wrapper.go
@@ -72,7 +72,7 @@ func (hw *HandlerWrapper) Invoke(ctx context.Context, payload interface{}) (resp
 			return
 		}
 
-		logger.Debug("Setting function to timeout in", time.Until(timeoutDuration).String())
+		logger.Debug("Setting function to timeout in ", time.Until(timeoutDuration).String())
 
 		timeoutChannel := time.After(time.Until(timeoutDuration))
 

--- a/report.go
+++ b/report.go
@@ -154,7 +154,7 @@ func NewReport(handler *HandlerWrapper) *Report {
 	lc := handler.lambdaContext
 	if lc == nil {
 		lc = &lambdacontext.LambdaContext{
-			AwsRequestID:       "Missing-Request-Id",
+			AwsRequestID:       generateUUID(),
 			InvokedFunctionArn: fmt.Sprintf("arn:aws:lambda:local:0:function:%s", lambdacontext.FunctionName),
 		}
 	}

--- a/report.go
+++ b/report.go
@@ -1,6 +1,7 @@
 package iopipe
 
 import (
+	"fmt"
 	"os"
 	"sync"
 	"time"
@@ -153,7 +154,8 @@ func NewReport(handler *HandlerWrapper) *Report {
 	lc := handler.lambdaContext
 	if lc == nil {
 		lc = &lambdacontext.LambdaContext{
-			AwsRequestID: "ERROR",
+			AwsRequestID:       "Missing-Request-Id",
+			InvokedFunctionArn: fmt.Sprintf("arn:aws:lambda:local:0:function:%s", lambdacontext.FunctionName),
 		}
 	}
 

--- a/report_test.go
+++ b/report_test.go
@@ -49,8 +49,8 @@ const emptyReport = `
   "aws": {
     "functionName": "",
     "functionVersion": "",
-    "awsRequestId": "ERROR",
-    "invokedFunctionArn": "",
+    "awsRequestId": "Missing-Request-Id",
+    "invokedFunctionArn": "arn:aws:lambda:local:0:function:",
     "logGroupName": "",
     "logStreamName": "",
     "memoryLimitInMB": 0,

--- a/report_test.go
+++ b/report_test.go
@@ -49,7 +49,7 @@ const emptyReport = `
   "aws": {
     "functionName": "",
     "functionVersion": "",
-    "awsRequestId": "Missing-Request-Id",
+    "awsRequestId": {{.AWS.AWSRequestID}},
     "invokedFunctionArn": "arn:aws:lambda:local:0:function:",
     "logGroupName": "",
     "logStreamName": "",

--- a/report_test.go
+++ b/report_test.go
@@ -49,7 +49,7 @@ const emptyReport = `
   "aws": {
     "functionName": "",
     "functionVersion": "",
-    "awsRequestId": {{.AWS.AWSRequestID}},
+    "awsRequestId": "{{.AWS.AWSRequestID}}",
     "invokedFunctionArn": "arn:aws:lambda:local:0:function:",
     "logGroupName": "",
     "logStreamName": "",

--- a/reporter.go
+++ b/reporter.go
@@ -65,7 +65,7 @@ func sendReport(report *Report) error {
 	defer res.Body.Close()
 
 	resbody, err := ioutil.ReadAll(res.Body)
-	logger.Debug("body read from IOPIPE", string(resbody))
+	logger.Debug("body read from IOPIPE ", string(resbody))
 	if err != nil {
 		return err
 	}

--- a/util.go
+++ b/util.go
@@ -1,6 +1,8 @@
 package iopipe
 
 import (
+	"crypto/rand"
+	"io"
 	"reflect"
 	"runtime"
 )
@@ -65,4 +67,14 @@ func strToBool(s string) *bool {
 	}
 
 	return False()
+}
+
+func generateUUID() string {
+	var uuid UUID
+	io.ReadFull(rand.Reader, uuid[:])
+
+	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
+	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
+
+	return uuid.String()
 }


### PR DESCRIPTION
Creates InvokedFunctionArn if it's unavailable on the context, in the same fashion that the JS core agent does. Also updates the RequestId to something other than "ERROR" (although, would update this to a UUID if that makes more sense? was following intent)

Also updates whitespace in some log statements.