### PR TITLE
Fix baseline-coldstart and coldstart acceptance tests

### DIFF
--- a/acceptance/serverless/baseline-coldstart/main.go
+++ b/acceptance/serverless/baseline-coldstart/main.go
@@ -7,9 +7,7 @@ import (
 )
 
 func handler() (string, error) {
-	defer os.Exit(1)
-
-	return "Invocation successful", nil
+	os.Exit(1)
 }
 
 func main() {

--- a/acceptance/serverless/coldstart/main.go
+++ b/acceptance/serverless/coldstart/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/aws/aws-lambda-go/lambda"
@@ -9,10 +10,13 @@ import (
 
 var agent = iopipe.NewAgent(iopipe.Config{Debug: iopipe.True()})
 
-func handler() (string, error) {
-	defer os.Exit(1)
+func handler(ctx context.Context) (string, error) {
+	context, _ := iopipe.FromContext(ctx)
 
-	return "Invocation successful", nil
+	// Send the report before exiting
+	context.IOpipe.Error(nil)
+
+	os.Exit(1)
 }
 
 func main() {


### PR DESCRIPTION
The coldstart acceptance test nevr reports because it exits before the
report is sent. Could defer to a goroutine that sleeps here, but that
introduces a race condition. So instead, we manually report and exit.

Removing the deferred statement from the baseline, too, as it's
unnecessary.

Signed-off-by: Michael Lavers <kolanos@gmail.com>